### PR TITLE
Add support for batch-deleting/batch-selecting bundle items.

### DIFF
--- a/dist/assets/checkbox.svg
+++ b/dist/assets/checkbox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"/></svg>

--- a/dist/assets/delete-sweep.svg
+++ b/dist/assets/delete-sweep.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15 16h4v2h-4zm0-8h7v2h-7zm0 4h6v2h-6zM3 18c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V8H3v10zm2-8h6v8H5v-8zm5-6H6L5 5H2v2h12V5h-3z"/></svg>

--- a/dist/assets/light-checkbox.svg
+++ b/dist/assets/light-checkbox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"/></svg>

--- a/dist/assets/light-delete-sweep.svg
+++ b/dist/assets/light-delete-sweep.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15 16h4v2h-4zm0-8h7v2h-7zm0 4h6v2h-6zM3 18c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V8H3v10zm2-8h6v8H5v-8zm5-6H6L5 5H2v2h12V5h-3z"/></svg>

--- a/dist/assets/light-trash.svg
+++ b/dist/assets/light-trash.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg>

--- a/dist/assets/trash.svg
+++ b/dist/assets/trash.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg>

--- a/dist/options/options.css
+++ b/dist/options/options.css
@@ -243,30 +243,32 @@ h2 {
     display: block;
 }
 
-.list-type-options {
+.options-list {
     margin: 1.5rem 0;
 }
 
-.list-type {
+.option-item {
     margin: 0.75rem 0;
 }
 
-input[type="radio"] {
+input[type="radio"],
+input[type="checkbox"] {
     height: 0;
     opacity: 0;
     position: absolute;
     width: 0;
 }
 
-input[type="radio"] + label {
+input[type="radio"] + label,
+input[type="checkbox"] + label {
     cursor: pointer;
     padding-left: 26px;
     position: relative;
 }
 
-input[type="radio"] + label::before {
+input[type="radio"] + label::before,
+input[type="checkbox"] + label::before {
     border: 1px solid #c4c4c4;
-    border-radius: 50%;
     top: 0;
     content: '';
     height: 16px;
@@ -275,9 +277,9 @@ input[type="radio"] + label::before {
     width: 16px;
 }
 
-input[type="radio"] + label::after {
+input[type="radio"] + label::after,
+input[type="checkbox"] + label::after {
     background-color: #00acc1;
-    border-radius: 50%;
     top: 4px;
     content: '';
     height: 10px;
@@ -287,12 +289,24 @@ input[type="radio"] + label::after {
     transition: transform 0.2s ease;
 }
 
-input[type="radio"]:not(:checked) + label::after {
+input[type="radio"]:not(:checked) + label::after,
+input[type="checkbox"]:not(:checked) + label::after {
     transform: scale(0);
 }
 
-input[type="radio"](:checked) + label::after {
+input[type="radio"]:checked + label::after,
+input[type="checkbox"]:checked + label::after {
     transform: scale(1);
+}
+
+input[type="radio"] + label::before,
+input[type="radio"] + label::after {
+    border-radius: 50%;
+}
+
+input[type="checkbox"] + label::before,
+input[type="checkbox"] + label::after {
+    border-radius: 10%;
 }
 
 textarea {

--- a/dist/options/options.html
+++ b/dist/options/options.html
@@ -200,9 +200,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </div>
 
         <div class="tab">
-            <h1>
-                Options
-            </h1>
+            <h1>Options</h1>
+
             <h2>
                 Labels
                 <div class="help-container">
@@ -213,18 +212,37 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 </div>
             </h2>
             
-            <div class="list-type-options">
-                <div class="list-type">
-                    <input type="radio" name="listType" value="exclude" id="exclude-radio">
+            <div class="options-list">
+                <div class="option-item">
+                    <input type="radio" value="exclude" id="exclude-radio">
                     <label for="exclude-radio">Bundle all labels except those in the following list:</label>
                 </div>
-                <div class="list-type">
-                    <input type="radio" name="listType" value="include" id="include-radio">
+                <div class="option-item">
+                    <input type="radio" value="include" id="include-radio">
                     <label for="include-radio">Only bundle labels in the following list:</label>
                 </div>
             </div>
 
             <textarea id="label-list" rows="16"></textarea>
+
+            <h2>
+                Actions
+            </h2>
+
+            <div class="options-list">
+                <div class="option-item">
+                    <input type="checkbox" class="action" value="archive" id="archive-checkbox">
+                    <label for="archive-checkbox">Show an "Archive all" button</label>
+                </div>
+                <div class="option-item">
+                    <input type="checkbox" class="action" value="delete" id="delete-checkbox">
+                    <label for="delete-checkbox">Show a "Delete all" button</label>
+                </div>
+                <div class="option-item">
+                    <input type="checkbox" class="action" value="select" id="select-checkbox">
+                    <label for="select-checkbox">Show a "Select all" button</label>
+                </div>
+            </div>
 
             <h2>
                 Group by date

--- a/dist/options/options.js
+++ b/dist/options/options.js
@@ -22,9 +22,13 @@ function saveOptions() {
     const labels = labelList.value.split(/[\n]+/).map(s => s.trim()).filter(s => !!s);
     const groupMessagesByDate = document.getElementById('group-by-date-checkbox').checked;
 
+    const actionButtons = document.querySelectorAll('.action:checked');
+    const actions = [...actionButtons].map(button => button.value);
+
     chrome.storage.sync.set({
         exclude: !!exclude,
         labels: labels,
+        actions: actions,
         groupMessagesByDate: !!groupMessagesByDate,
     }, function() {
         labelList.value = labels.join('\n');
@@ -41,6 +45,7 @@ function restoreOptions() {
     chrome.storage.sync.get({
         exclude: true,
         labels: [],
+        actions: ['archive'],
         groupMessagesByDate: true,
     }, function(items) {
         const id = items.exclude ? 'exclude-radio' : 'include-radio';
@@ -52,8 +57,11 @@ function restoreOptions() {
           labelList.placeholder = PLACEHOLDER;
         }
 
-        document.getElementById('group-by-date-checkbox').checked = items.groupMessagesByDate;
+        for (const action of items.actions) {
+            document.getElementById(`${action}-checkbox`).checked = true;
+        }
 
+        document.getElementById('group-by-date-checkbox').checked = items.groupMessagesByDate;
     });
 }
 document.getElementById('save-button').addEventListener('click', saveOptions);

--- a/dist/style.css
+++ b/dist/style.css
@@ -179,64 +179,66 @@ html.inboxy .bundle-row .flex-grow {
     flex-grow: 1;
 }
 
-html.inboxy .bundle-row .archive-bundle {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/check-all.svg');
-    background-size: 24px;
-    display: none;
-    height: 20px;
-    width: 24px;
+html.inboxy .bundle-row > .select {
+    margin-left: 4px;
+    opacity: .54;
+}
+html.inboxy .bundle-row:hover > .select {
+    opacity: .7;
 }
 
-html.inboxy .bundle-row:not(.visible) .archive-bundle {
-    margin-right: 16px;
+html.inboxy .bundle-row .bulk-action {
+    background-size: 20px;
+    display: none;
+    height: 20px;
+    width: 20px;
+}
+
+html.inboxy .bundle-row .bulk-action.select {
+    display: block;
+}
+
+html.inboxy .bundle-row:not(.visible) .bulk-action:last-of-type {
+    margin-right: 12px;
+}
+html.inboxy .bundle-row:not(.visible) .bulk-action {
+    margin-right: 8px;
 }
 
 /** Adjust size of circle on hover */
-html.inboxy .bundle-row .archive-bundle:before {
+html.inboxy .bundle-row .bulk-action:before {
     left: -8px;
     right: -8px;
 }
-html.inboxy.compact .bundle-row .archive-bundle:before {
+html.inboxy.compact .bundle-row .bulk-action:before {
     left: -2px;
     right: -2px;
 }
 
 /** Show on hover */
-html.inboxy .bundle-row:hover .archive-bundle {
+html.inboxy .bundle-row:hover .bulk-action {
     display: block;
 }
 
-html.inboxy.dark-theme .bundle-row.visible .archive-bundle,
-html.inboxy.messages-dark-theme .bundle-row:not(.visible) .archive-bundle {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
+html.inboxy.dark-theme .bundle-row.visible .bulk-action,
+html.inboxy.messages-dark-theme .bundle-row:not(.visible) .bulk-action {
     opacity: 0.7;
 }
 
-html.inboxy.dark-theme .bundle-row.visible .archive-bundle:before {
+html.inboxy.dark-theme .bundle-row.visible .bulk-action:before {
     background-color: rgb(255, 255, 255, 0.2);
 }
 
-@-moz-document url-prefix() {
-    html.inboxy .bundle-row .archive-bundle {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/check-all.svg');
-    }
-
-    html.inboxy.dark-theme .bundle-row.visible .archive-bundle,
-    html.inboxy.messages-dark-theme .bundle-row:not(.visible) .archive-bundle {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
-    }
-}
-
-html.inboxy .bundle-row.visible .archive-bundle {
+html.inboxy .bundle-row.visible .bulk-action {
     display: block;
 }
 
-html.inboxy .bundle-row .archive-bundle.disabled {
+html.inboxy .bundle-row .bulk-action.disabled {
     cursor: default;
     opacity: .15;
 }
 
-html.inboxy .bundle-row .archive-bundle.disabled::before {
+html.inboxy .bundle-row .bulk-action::before {
     display: none;
 }
 
@@ -287,8 +289,8 @@ html.inboxy .bundled-message.visible.last {
 
 html.inboxy .date-row {
     display: flex;
-    justify-content: space-between;
-    padding: 24px 0 16px 28px;
+    justify-content: stretch;
+    padding: 24px 0 16px 6px;
     font-size: 0.94rem;
     color: #202124;
 }
@@ -298,55 +300,98 @@ html.inboxy.dark-theme .date-row {
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
 }
 
-html.inboxy .date-row .archive-bundle {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/check-all.svg');
-    background-size: 20px;
-    margin-right: 24px;
+html.inboxy .date-row .bulk-action.archive {
+    margin-left: auto;
 }
 
-html.inboxy.dark-theme .date-row .archive-bundle {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
+html.inboxy .date-row .bulk-action {
+    background-size: 20px;
+    margin-right: 10px;
+}
+
+html.inboxy.dark-theme .date-row .bulk-action {
     opacity: 0.7;
 }
 
-html.inboxy.dark-theme .date-row .archive-bundle:before {
+html.inboxy.dark-theme .date-row .bulk-action:before {
     background-color: rgb(255, 255, 255, 0.2);
-}
-
-@-moz-document url-prefix() {
-    html.inboxy .date-row .archive-bundle {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/check-all.svg');
-    }
-
-    html.inboxy.dark-theme .date-row .archive-bundle {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
-    }
 }
 
 /** 
  * Archive button 
  */
-html.inboxy .brq,
-html.inboxy .ar8 {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/check.svg');
+html.inboxy .bulk-action.archive {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/check-all.svg');
 }
 
-html.inboxy.messages-dark-theme .brq,
-html.inboxy.dark-theme .ar8 {
-    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-check.svg');
+html.inboxy.dark-theme .bulk-action.archive {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
 }
 
 @-moz-document url-prefix() {
-    html.inboxy .brq,
-    html.inboxy .ar8 {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/check.svg');
+    html.inboxy .bulk-action.archive {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/check-all.svg');
     }
 
-    html.inboxy.messages-dark-theme .brq,
-    html.inboxy.dark-theme .ar8 {
-        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-check.svg');
+    html.inboxy.dark-theme .bulk-action.archive {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-check-all.svg');
     }
 }
+
+html.inboxy.hide-archive-action .bulk-action.archive {
+    display: none;
+}
+
+/**
+ * Delete button
+ */
+html.inboxy .bulk-action.delete {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/delete-sweep.svg');
+}
+
+html.inboxy.dark-theme .bulk-action.delete {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-delete-sweep.svg');
+}
+
+@-moz-document url-prefix() {
+    html.inboxy .bulk-action.delete {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/delete-sweep.svg');
+    }
+
+    html.inboxy.dark-theme .bulk-action.delete {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-delete-sweep.svg');
+    }
+}
+
+html.inboxy.hide-delete-action .bulk-action.delete {
+    display: none;
+}
+
+/**
+ * Select button
+ */
+html.inboxy .bulk-action.select {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/checkbox.svg');
+}
+
+html.inboxy.dark-theme .bulk-action.select {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/assets/light-checkbox.svg');
+}
+
+@-moz-document url-prefix() {
+    html.inboxy .bulk-action.select {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/checkbox.svg');
+    }
+
+    html.inboxy.dark-theme .bulk-action.select {
+        background-image: url('moz-extension://__MSG_@@extension_id__/assets/light-checkbox.svg');
+    }
+}
+
+html.inboxy.hide-select-action .bulk-action.select {
+    display: none;
+}
+
 
 /**
  * View all link 

--- a/src/bundling/Bundler.js
+++ b/src/bundling/Bundler.js
@@ -310,7 +310,7 @@ class Bundler {
 
     _applyStyles(messageNodes) {
         this.inboxyStyler.markSelectedBundles();
-        this.inboxyStyler.disableBulkArchiveIfNecessary();
+        this.inboxyStyler.disableBulkActionsIfNecessary();
     }
 
     _attachHandlers(messageNodes, messageList) {

--- a/src/bundling/InboxyStyler.js
+++ b/src/bundling/InboxyStyler.js
@@ -66,29 +66,33 @@ class InboxyStyler {
     }
 
     /**
-     * For each bundle, disable bulk-archiving if any message outside of its bundle is selected.
+     * For each bundle, disable bulk-actions if any message outside of its bundle is selected.
      */
-    disableBulkArchiveIfNecessary() {
+    disableBulkActionsIfNecessary() {
         const selectedMessages = [].slice.call(
             document.querySelectorAll(Selectors.SELECTED));
         Object.values(this.bundledMail.getAllBundles()).forEach(bundle => 
-            this._updateBulkArchiveButton(bundle, selectedMessages));
+            this._updateBulkActionButtons(bundle, selectedMessages));
     }
 
     /**
-     * Enable/disable the bulk archive button for the given bundle.
+     * Enable/disable the bulk action buttons for the given bundle.
      */
-    _updateBulkArchiveButton(bundle, selectedMessages) {
+    _updateBulkActionButtons(bundle, selectedMessages) {
         const bundledMessageIds = new Set(bundle.getMessages().map(m => m.id));
         const allSelectedMessagesInBundle = !selectedMessages.some(
             m => !bundledMessageIds.has(m.id));
+        const bulkActionButtons = bundle.getBundleRow().getElementsByClassName('bulk-action');
 
-        const bulkArchiveButton = bundle.getBundleRow().querySelector('.archive-bundle');
         if (allSelectedMessagesInBundle) {
-            bulkArchiveButton.classList.remove('disabled');
+            for (const bulkActionButton of bulkActionButtons) {
+                bulkActionButton.classList.remove('disabled');
+            }
         }
         else {
-            bulkArchiveButton.classList.add('disabled');
+            for (const bulkActionButton of bulkActionButtons) {
+                bulkActionButton.classList.add('disabled');
+            }
         }
     }
 }

--- a/src/components/BundleRow.js
+++ b/src/components/BundleRow.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import BulkArchiveButton from './BulkArchiveButton';
+import BulkActionButton from './BulkActionButton';
 
 import MessagePageUtils from '../util/MessagePageUtils';
 import DomUtils from '../util/DomUtils';
@@ -56,7 +56,6 @@ function create(label, order, messages, hasUnread, toggleBundle, baseUrl) {
     const html = `
         <tr class="${GmailClasses.ROW} ${InboxyClasses.BUNDLE_ROW} ${unreadClass}">
             <td class="${GmailClasses.CELL} PF"></td>
-            <td class="${GmailClasses.CELL} oZ-x3"></td>
             <td class="${GmailClasses.CELL} apU"></td>
             <td class="spacer ${GmailClasses.CELL} ${spacerClass}"></td>
             <td class="${GmailClasses.CELL} yX">
@@ -74,9 +73,14 @@ function create(label, order, messages, hasUnread, toggleBundle, baseUrl) {
         </tr>
     `;
 
-    const bulkArchiveButton = BulkArchiveButton.create(messages);
-    const bulkArchiveTd = DomUtils.htmlToElement(`<td class="${GmailClasses.CELL}"></td>`);
-    bulkArchiveTd.appendChild(bulkArchiveButton);
+    const bulkArchiveButton = BulkActionButton.createArchive(messages);
+    const bulkDeleteButton = BulkActionButton.createDelete(messages);
+    const bulkSelectButton = BulkActionButton.createSelect(messages);
+    const bulkActionsTd = DomUtils.htmlToElement(`<td class="${GmailClasses.CELL}"></td>`);
+    bulkActionsTd.appendChild(bulkArchiveButton);
+    bulkActionsTd.appendChild(bulkDeleteButton);
+    const bulkSelectTd = DomUtils.htmlToElement(`<td class="${GmailClasses.CELL} select" style="order: 0;"></td>`);
+    bulkSelectTd.appendChild(bulkSelectButton);
 
     const labelUrl = label
         .split(' ').join('-')
@@ -105,8 +109,9 @@ function create(label, order, messages, hasUnread, toggleBundle, baseUrl) {
     `;
 
     const el = DomUtils.htmlToElement(html);
-    el.appendChild(bulkArchiveTd);
+    el.insertBefore(bulkSelectTd, el.childNodes[2]);
     el.appendChild(DomUtils.htmlToElement(bundleDateHtml));
+    el.appendChild(bulkActionsTd);
     el.appendChild(DomUtils.htmlToElement(viewAllButtonHtml));
 
     el.addEventListener('click', e => {

--- a/src/components/DateDivider.js
+++ b/src/components/DateDivider.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import BulkArchiveButton from '../components/BulkArchiveButton';
+import BulkActionButton from '../components/BulkActionButton';
 
 import DomUtils from '../util/DomUtils';
 import {
@@ -115,13 +115,15 @@ function findMessagesForDivider(tableRows, dividerIndex) {
 function create(divider, order, messages) {
     const html = `
         <div class="date-row">
-            ${divider.text}
+            <span>${divider.text}</span>
         </div>
     `;
     const el = DomUtils.htmlToElement(html);
     el.style.order = order;
 
-    el.appendChild(BulkArchiveButton.create(messages));
+    el.insertBefore(BulkActionButton.createSelect(messages), el.firstChild);
+    el.appendChild(BulkActionButton.createArchive(messages));
+    el.appendChild(BulkActionButton.createDelete(messages));
 
     return el;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -29,6 +29,9 @@ import MessageListWatcher from './handlers/MessageListWatcher';
 import StarHandler from './handlers/StarHandler';
 import ThemeChangeHandler from './handlers/ThemeChangeHandler';
 
+import {
+    getActionsToDisplay,
+} from './util/ActionUtils';
 import { 
     InboxyClasses,
     Selectors,
@@ -139,6 +142,7 @@ function handleContentLoaded() {
     const bundleCurrentPage = supportsBundling(window.location.href);
     logDebugMessage(`Url: ${window.location.href}, page supports bundling: ${bundleCurrentPage}`);
     tryBundling(0, bundleCurrentPage);
+    hideBulkActionButtonsIfNecessary();
 }
 
 function tryBundling(i, bundleCurrentPage) {
@@ -195,4 +199,18 @@ function startObservers() {
 function addPinnedToggle() {
     const searchForm = document.querySelector(Selectors.SEARCH_FORM).parentNode;
     searchForm.appendChild((new PinnedToggle()).create());
+}
+
+function hideBulkActionButtonsIfNecessary() {
+    getActionsToDisplay().then(actions => {
+        if (!actions.archive) {
+            html.classList.add('hide-archive-action');
+        }
+        if (!actions.delete) {
+            html.classList.add('hide-delete-action');
+        }
+        if (!actions.select) {
+            html.classList.add('hide-select-action');
+        }
+    });
 }

--- a/src/handlers/MessageSelectHandler.js
+++ b/src/handlers/MessageSelectHandler.js
@@ -95,7 +95,7 @@ class MessageSelectHandler {
             {
                 this.inboxyStyler.markSelectedBundlesFor(
                     this.selectiveBundling.findRelevantLabels(message));
-                this.inboxyStyler.disableBulkArchiveIfNecessary();
+                this.inboxyStyler.disableBulkActionsIfNecessary();
             }
         });    
     }

--- a/src/util/ActionUtils.js
+++ b/src/util/ActionUtils.js
@@ -1,0 +1,29 @@
+// inboxy: Chrome extension for Google Inbox-style bundles in Gmail.
+// Copyright (C) 2020  Teresa Ou
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function getActionsToDisplay() {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get(['actions'], ({ actions = ['archive'] }) => {
+            resolve({
+                archive: actions.includes('archive'),
+                delete: actions.includes('delete'),
+                select: actions.includes('select'),
+            });
+        });
+    });
+}
+
+export { getActionsToDisplay };

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -30,6 +30,7 @@ const GmailClasses = {
     ARCHIVE_BUTTON: 'brq bqX',
     CELL: 'xY',
     DATE_CELL: 'xW',
+    DELETE_BUTTON: 'ar9 bqX',
     IMPORTANCE_MARKER: 'WA',
     PERSONAL_LEVEL_INDICATOR: 'bnk',
     READ: 'yO',
@@ -49,6 +50,7 @@ const InboxyClasses = {
     MESSAGES_DARK_THEME: 'messages-dark-theme',
     INBOXY: 'inboxy',
     LAST: 'last',
+    SELECT_BUTTON: 'select-all bqX',
     SHOW_PINNED_TOGGLE: 'show-pinned-toggle',
     VIEW_ALL_LINK: 'view-all-link',
     VISIBLE: 'visible',
@@ -92,6 +94,7 @@ const Selectors = {
     TABPANELS: `${MAIN} [role="tabpanel"]`,
     TABLE_BODY: `.F tbody`,
     TOOLBAR_ARCHIVE_BUTTON: `.G-atb:not([style*="none"]) .T-I.J-J5-Ji[act="7"]`,
+    TOOLBAR_DELETE_BUTTON: `.G-atb:not([style*="none"]) .T-I.J-J5-Ji[act="10"]`,
     UNSTARRED: `.T-KT.aXw`,
 };
 


### PR DESCRIPTION
This adds new icon buttons along with "archive all": "delete all" and "select all." In "Options," these buttons can be toggled on and off (the default is to only show the "archive all" button, like now).

Please let me know if you have suggestions. The icons come directly from Material Icons so you may want to modify them. I did not add a custom style for the checkboxes in the options page either.